### PR TITLE
Support building XSP in Visual Studio against the .NET runtime.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ Makefile.in
 *.mdb
 *.dll
 *.exe
+*.suo
+bin
+obj
+*.user

--- a/src/Mono.WebServer.XSP/Mono.WebServer.XSP.csproj
+++ b/src/Mono.WebServer.XSP/Mono.WebServer.XSP.csproj
@@ -1,0 +1,86 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{7BF7CF20-CB52-4AD1-8BB5-CDC3C3A05B92}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Mono.WebServer.XSP</RootNamespace>
+    <AssemblyName>Mono.WebServer.XSP</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\DeployFu\bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject>
+    </StartupObject>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>
+    </AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Mono.Security">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Mono-2.8.1\lib\mono\4.0\Mono.Security.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="main.cs" />
+    <Compile Include="SecurityConfiguration.cs" />
+    <Compile Include="SslInformation.cs" />
+    <Compile Include="XSPApplicationHost.cs" />
+    <Compile Include="XSPRequestBroker.cs" />
+    <Compile Include="XSPWebSource.cs" />
+    <Compile Include="XSPWorker.cs" />
+    <Compile Include="XSPWorkerRequest.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Mono.WebServer\Mono.WebServer.csproj">
+      <Project>{6B354D8B-17FC-48EB-B899-914885DB81DF}</Project>
+      <Name>Mono.WebServer</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Mono.WebServer/Mono.WebServer.csproj
+++ b/src/Mono.WebServer/Mono.WebServer.csproj
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{6B354D8B-17FC-48EB-B899-914885DB81DF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Mono.WebServer</RootNamespace>
+    <AssemblyName>Mono.WebServer</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\DeployFu\bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>
+    </AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ApplicationServer.cs" />
+    <Compile Include="BaseApplicationHost.cs" />
+    <Compile Include="BaseRequestBroker.cs" />
+    <Compile Include="EndOfRequestHandler.cs" />
+    <Compile Include="HttpErrors.cs" />
+    <Compile Include="IApplicationHost.cs" />
+    <Compile Include="InitialWorkerRequest.cs" />
+    <Compile Include="IRequestBroker.cs" />
+    <Compile Include="LingeringNetworkStream.cs" />
+    <Compile Include="LockRecursionException.cs" />
+    <Compile Include="LockRecursionPolicy.cs" />
+    <Compile Include="MapPathEventArgs.cs" />
+    <Compile Include="MapPathEventHandler.cs" />
+    <Compile Include="MonoWorkerRequest.cs" />
+    <Compile Include="Paths.cs" />
+    <Compile Include="ReaderWriterLockSlim.cs" />
+    <Compile Include="RequestData.cs" />
+    <Compile Include="RequestLineException.cs" />
+    <Compile Include="SearchPattern.cs" />
+    <Compile Include="UnregisterRequestEventArgs.cs" />
+    <Compile Include="UnregisterRequestEventHandler.cs" />
+    <Compile Include="VPathToHost.cs" />
+    <Compile Include="WebSource.cs" />
+    <Compile Include="WebTrace.cs" />
+    <Compile Include="Worker.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/xsp/Program.cs
+++ b/src/xsp/Program.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Reflection;
+
+namespace xsp
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            //Assembly ass = Assembly.Load("Mono.WebServer.XSP");
+            Mono.WebServer.XSP.Server.Main(args);
+        }
+    }
+}

--- a/src/xsp/Properties/AssemblyInfo.cs
+++ b/src/xsp/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("xsp")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyProduct("xsp")]
+[assembly: AssemblyCopyright("Copyright © Microsoft 2011")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("26d27b89-8671-4885-a5dc-9c15c8d32840")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/xsp/app.config
+++ b/src/xsp/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>

--- a/src/xsp/xsp.csproj
+++ b/src/xsp/xsp.csproj
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{EF865D93-8B54-4A1E-B02A-FEE18D5A771F}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>xsp</RootNamespace>
+    <AssemblyName>xsp</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\DeployFu\bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject>xsp.Program</StartupObject>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Mono.WebServer.XSP\Mono.WebServer.XSP.csproj">
+      <Project>{7BF7CF20-CB52-4AD1-8BB5-CDC3C3A05B92}</Project>
+      <Name>Mono.WebServer.XSP</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/xsp4.sln
+++ b/src/xsp4.sln
@@ -1,0 +1,54 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.WebServer", "Mono.WebServer\Mono.WebServer.csproj", "{6B354D8B-17FC-48EB-B899-914885DB81DF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.WebServer.XSP", "Mono.WebServer.XSP\Mono.WebServer.XSP.csproj", "{7BF7CF20-CB52-4AD1-8BB5-CDC3C3A05B92}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xsp", "xsp\xsp.csproj", "{EF865D93-8B54-4A1E-B02A-FEE18D5A771F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|Mixed Platforms = Debug|Mixed Platforms
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|Mixed Platforms = Release|Mixed Platforms
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6B354D8B-17FC-48EB-B899-914885DB81DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B354D8B-17FC-48EB-B899-914885DB81DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B354D8B-17FC-48EB-B899-914885DB81DF}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{6B354D8B-17FC-48EB-B899-914885DB81DF}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{6B354D8B-17FC-48EB-B899-914885DB81DF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6B354D8B-17FC-48EB-B899-914885DB81DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6B354D8B-17FC-48EB-B899-914885DB81DF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6B354D8B-17FC-48EB-B899-914885DB81DF}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{6B354D8B-17FC-48EB-B899-914885DB81DF}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{6B354D8B-17FC-48EB-B899-914885DB81DF}.Release|x86.ActiveCfg = Release|Any CPU
+		{7BF7CF20-CB52-4AD1-8BB5-CDC3C3A05B92}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7BF7CF20-CB52-4AD1-8BB5-CDC3C3A05B92}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7BF7CF20-CB52-4AD1-8BB5-CDC3C3A05B92}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{7BF7CF20-CB52-4AD1-8BB5-CDC3C3A05B92}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{7BF7CF20-CB52-4AD1-8BB5-CDC3C3A05B92}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7BF7CF20-CB52-4AD1-8BB5-CDC3C3A05B92}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7BF7CF20-CB52-4AD1-8BB5-CDC3C3A05B92}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7BF7CF20-CB52-4AD1-8BB5-CDC3C3A05B92}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{7BF7CF20-CB52-4AD1-8BB5-CDC3C3A05B92}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{7BF7CF20-CB52-4AD1-8BB5-CDC3C3A05B92}.Release|x86.ActiveCfg = Release|Any CPU
+		{EF865D93-8B54-4A1E-B02A-FEE18D5A771F}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{EF865D93-8B54-4A1E-B02A-FEE18D5A771F}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{EF865D93-8B54-4A1E-B02A-FEE18D5A771F}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{EF865D93-8B54-4A1E-B02A-FEE18D5A771F}.Debug|x86.ActiveCfg = Debug|x86
+		{EF865D93-8B54-4A1E-B02A-FEE18D5A771F}.Debug|x86.Build.0 = Debug|x86
+		{EF865D93-8B54-4A1E-B02A-FEE18D5A771F}.Release|Any CPU.ActiveCfg = Release|x86
+		{EF865D93-8B54-4A1E-B02A-FEE18D5A771F}.Release|Mixed Platforms.ActiveCfg = Release|x86
+		{EF865D93-8B54-4A1E-B02A-FEE18D5A771F}.Release|Mixed Platforms.Build.0 = Release|x86
+		{EF865D93-8B54-4A1E-B02A-FEE18D5A771F}.Release|x86.ActiveCfg = Release|x86
+		{EF865D93-8B54-4A1E-B02A-FEE18D5A771F}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This patch allows compilation of XSP on Windows with Visual Studio against the .NET runtime. XSP is nice to have in a pinch as a quick way to host websites externally, as IIS can be nontrivial to set up, and the Visual Studio web server is localhost accessible only.

You may be wondering "Why not use the Mono Runtime to run XSP"? ASP .NET MVC 3 is currently not supported by Mono. I spent a couple hours attempting to get MVC 3 compiling against mono with no luck; gmcs crashes, missing classes, etc. This also allows for a very small footprint installation (just 4 assemblies).

Koush

I submit this under the MIT license.
