### PR TITLE
XSP Apache ipv6

### DIFF
--- a/src/Mono.WebServer.Apache/ModMonoWorker.cs
+++ b/src/Mono.WebServer.Apache/ModMonoWorker.cs
@@ -192,14 +192,11 @@ namespace Mono.WebServer
 			string vhost = rr.Request.GetRequestHeader ("Host");
 			int port = -1;
 			if (vhost != null) {
-				int colon = vhost.IndexOf (':');
-				if (colon != -1) {
-					port = Int32.Parse (vhost.Substring (colon + 1));
-					vhost = vhost.Substring (0, colon);
-				} else {
-					port = 80;
-				}
-			}
+        Uri u = new Uri("http://" + vhost);
+        port = u.Port;
+			} else {
+        port = 80;
+      }
 
 			string vServerName = rr.Request.GetVirtualServerName ();
 			if (vServerName == null)


### PR DESCRIPTION
Uses System.Uri for getting the port number from the http request, makes ipv6 work.
Might not be the best way since it could have performance penalties.
