### PR TITLE
Ensuring body_length is correctly set for FastCGI requests.

### DIFF
--- a/src/Mono.WebServer.FastCgi/Record.cs
+++ b/src/Mono.WebServer.FastCgi/Record.cs
@@ -149,7 +149,7 @@ namespace Mono.FastCgi {
 			this.type = type;
 			request_id  = requestID;
 			buffers = new Buffers (bodyData, bodyIndex, bodyLength);
-			BodyLength = body_length = (ushort) bodyLength;
+			body_length = (ushort) bodyLength;
 		}
 		
 		#endregion


### PR DESCRIPTION
The BodyLength property must always be set; otherwise downstream callers (such as BeginRequestBody.cs) will be unable to validate the record and will throw an exception.
