### PR TITLE
fixed broken XSP build

### DIFF
--- a/src/Mono.WebServer.FastCgi/main.cs
+++ b/src/Mono.WebServer.FastCgi/main.cs
@@ -140,6 +140,7 @@ namespace Mono.WebServer.FastCgi {
 
 		static bool TryCreateOnDemandSocket (string onDemandSock, out Socket socket, out Uri uri)
 		{
+			socket = null;
 			return (Uri.TryCreate (onDemandSock, UriKind.Absolute, out uri) && TryCreateSocketFromUri (uri, out socket))
 				|| TryCreateUnixSocket (onDemandSock, out socket);
 		}


### PR DESCRIPTION
Making all in Mono.WebServer.FastCgi
  GMCS  /out:fastcgi-mono-server2.exe
././main.cs(141,72): error CS0177: The out parameter `socket' must be assigned to before control leaves the current method
