### PR TITLE
Detect *BSDs as supporting libc as well.

### DIFF
--- a/src/Mono.WebServer.FastCgi/Record.cs
+++ b/src/Mono.WebServer.FastCgi/Record.cs
@@ -168,8 +168,12 @@ namespace Mono.WebServer.FastCgi {
 
 			int total = 0;
 			while (total < length) {
-				total += socket.Send (data.Value.Array, data.Value.Offset + total,
-				                      length - total, System.Net.Sockets.SocketFlags.None);
+				int written = socket.Send(data.Value.Array, data.Value.Offset + total,
+				                          length - total, System.Net.Sockets.SocketFlags.None);
+				if (written <= 0)
+					throw new System.Net.Sockets.SocketException();
+
+				total += written;
 			}
 		}
 
@@ -180,9 +184,13 @@ namespace Mono.WebServer.FastCgi {
 
 			int total = 0;
 			while (total < length) {
-				total += socket.Receive (data.Array, total + data.Offset,
-				                         length - total,
-				                         System.Net.Sockets.SocketFlags.None);
+				int read = socket.Receive(data.Array, total + data.Offset,
+				                           length - total,
+				                           System.Net.Sockets.SocketFlags.None);
+				if (read <= 0)
+					throw new System.Net.Sockets.SocketException();
+
+				total += read;
 			}
 		}
 	}

--- a/src/Mono.WebServer.FastCgi/Sockets/UnmanagedSocket.cs
+++ b/src/Mono.WebServer.FastCgi/Sockets/UnmanagedSocket.cs
@@ -266,8 +266,33 @@ namespace Mono.WebServer.FastCgi.Sockets {
 		static UnmanagedSocket ()
 		{
 			try {
-				string os = File.ReadAllText("/proc/sys/kernel/ostype");
-				supports_libc = os.StartsWith ("Linux");
+				string uname;
+				try {
+					var p = new System.Diagnostics.Process();
+
+					p.StartInfo.UseShellExecute = false;
+					p.StartInfo.RedirectStandardOutput = true;
+					p.StartInfo.FileName = "uname";
+
+					p.Start();
+
+					uname = p.StandardOutput.ReadToEnd();
+					p.WaitForExit();
+					if (uname == null) 
+						uname = "";
+					uname = uname.Trim().ToLower();
+
+					supports_libc = uname.StartsWith("linux") ||
+						uname.StartsWith("freebsd") ||
+						uname.StartsWith("netbsd") ||
+						uname.StartsWith("openbsd");
+				} catch {
+					uname = "";
+				}
+				if (uname == "") {
+					string os = File.ReadAllText("/proc/sys/kernel/ostype");
+					supports_libc = os.StartsWith ("Linux");
+				}
 			} catch {
 			}
 		}


### PR DESCRIPTION
Modified fastcgi server to be able to use native (and local sockets) with *BSDs as well. I tested it on FreeBSD with lighttpd & local socket and it works as expected.
