### PR TITLE
Bug 25072 - mod-mono-server problem serving static files

### DIFF
--- a/src/Mono.WebServer.Apache/ModMonoWorkerRequest.cs
+++ b/src/Mono.WebServer.Apache/ModMonoWorkerRequest.cs
@@ -111,10 +111,10 @@ namespace Mono.WebServer
 				break;
 			}
 
-			string sfr = Environment.GetEnvironmentVariable("MOD_MONO_SEND_FILE");
+			string sfr = Environment.GetEnvironmentVariable("MOD_MONO_SEND_STATIC_FILE");
 			if (sfr != null)
 				sfr = sfr.ToLower(CultureInfo.InvariantCulture);
-			send_file_remote = sfr == "remote";
+			send_file_remote = sfr == "stream";
 		}
 
 		static void SetDefaultIndexFiles (string list)

--- a/src/Mono.WebServer.Apache/ModMonoWorkerRequest.cs
+++ b/src/Mono.WebServer.Apache/ModMonoWorkerRequest.cs
@@ -75,7 +75,7 @@ namespace Mono.WebServer
 		bool cert_validity;
 		readonly static bool cert_check_apache;
 		readonly static bool cert_check_mono;
-        readonly static bool send_file_remote;
+		readonly static bool send_file_remote;
 
 		string [][] unknownHeaders;
 		static string [] indexFiles = { "index.aspx",
@@ -111,10 +111,10 @@ namespace Mono.WebServer
 				break;
 			}
 
-            string sfr = Environment.GetEnvironmentVariable("MOD_MONO_SEND_FILE");
-            if (sfr != null)
-                sfr = sfr.ToLower(CultureInfo.InvariantCulture);
-            send_file_remote = sfr == "remote";
+			string sfr = Environment.GetEnvironmentVariable("MOD_MONO_SEND_FILE");
+			if (sfr != null)
+				sfr = sfr.ToLower(CultureInfo.InvariantCulture);
+			send_file_remote = sfr == "remote";
 		}
 
 		static void SetDefaultIndexFiles (string list)
@@ -581,19 +581,19 @@ namespace Mono.WebServer
 
 		public override void SendResponseFromFile (string filename, long offset, long length)
 		{
-            if (!send_file_remote)
-            {
-			    if (offset == 0) {
-				    var info = new FileInfo (filename);
-				    if (info.Length == length) {
-					    if (requestId == -1)
-						    worker.SendFile (filename);
-					    else
-						    requestBroker.SendFile (requestId, filename);
-					    return;
-				    }
-			    }
-            }
+			if (!send_file_remote)
+			{
+				if (offset == 0) {
+					var info = new FileInfo (filename);
+					if (info.Length == length) {
+						if (requestId == -1)
+							worker.SendFile (filename);
+						else
+							requestBroker.SendFile (requestId, filename);
+						return;
+					}
+				}
+			}
 
 			FileStream file = null;
 			try {

--- a/src/Mono.WebServer.Apache/ModMonoWorkerRequest.cs
+++ b/src/Mono.WebServer.Apache/ModMonoWorkerRequest.cs
@@ -116,7 +116,7 @@ namespace Mono.WebServer
 			string sfr = Environment.GetEnvironmentVariable("MOD_MONO_SEND_STATIC_FILE");
 			if (sfr != null)
 				sfr = sfr.ToLower(CultureInfo.InvariantCulture);
-			send_file_remote = sfr == "stream";
+			send_file_remote = sfr != "local";
 		}
 
 		static void SetDefaultIndexFiles (string list)

--- a/src/Mono.WebServer.Apache/ModMonoWorkerRequest.cs
+++ b/src/Mono.WebServer.Apache/ModMonoWorkerRequest.cs
@@ -75,6 +75,7 @@ namespace Mono.WebServer
 		bool cert_validity;
 		readonly static bool cert_check_apache;
 		readonly static bool cert_check_mono;
+        readonly static bool send_file_remote;
 
 		string [][] unknownHeaders;
 		static string [] indexFiles = { "index.aspx",
@@ -109,6 +110,11 @@ namespace Mono.WebServer
 				cert_check_mono = true;
 				break;
 			}
+
+            string sfr = Environment.GetEnvironmentVariable("MOD_MONO_SEND_FILE");
+            if (sfr != null)
+                sfr = sfr.ToLower(CultureInfo.InvariantCulture);
+            send_file_remote = sfr == "remote";
 		}
 
 		static void SetDefaultIndexFiles (string list)
@@ -575,16 +581,19 @@ namespace Mono.WebServer
 
 		public override void SendResponseFromFile (string filename, long offset, long length)
 		{
-			if (offset == 0) {
-				var info = new FileInfo (filename);
-				if (info.Length == length) {
-					if (requestId == -1)
-						worker.SendFile (filename);
-					else
-						requestBroker.SendFile (requestId, filename);
-					return;
-				}
-			}
+            if (!send_file_remote)
+            {
+			    if (offset == 0) {
+				    var info = new FileInfo (filename);
+				    if (info.Length == length) {
+					    if (requestId == -1)
+						    worker.SendFile (filename);
+					    else
+						    requestBroker.SendFile (requestId, filename);
+					    return;
+				    }
+			    }
+            }
 
 			FileStream file = null;
 			try {

--- a/src/Mono.WebServer.Apache/ModMonoWorkerRequest.cs
+++ b/src/Mono.WebServer.Apache/ModMonoWorkerRequest.cs
@@ -111,6 +111,8 @@ namespace Mono.WebServer
 				break;
 			}
 
+			// Sends the file as a content stream rather than path.
+			// This is important when we're running on a different host than httpd
 			string sfr = Environment.GetEnvironmentVariable("MOD_MONO_SEND_STATIC_FILE");
 			if (sfr != null)
 				sfr = sfr.ToLower(CultureInfo.InvariantCulture);

--- a/src/Mono.WebServer.Apache/main.cs
+++ b/src/Mono.WebServer.Apache/main.cs
@@ -121,7 +121,7 @@ namespace Mono.WebServer.Apache {
 				: new ModMonoWebSource (configurationManager.Filename, lockfile);
 
             if (configurationManager.MinThreads.HasValue)
-                ThreadPool.SetMinThreads(configurationManager.MinThreads.Value, configurationManager.MinThreads.Value);
+                ThreadPool.SetMinThreads(configurationManager.MinThreads.Value, 16);
 
 			if(configurationManager.Terminate) {
 				if (configurationManager.Verbose)

--- a/src/Mono.WebServer.Apache/main.cs
+++ b/src/Mono.WebServer.Apache/main.cs
@@ -120,6 +120,9 @@ namespace Mono.WebServer.Apache {
 				? new ModMonoTCPWebSource (configurationManager.Address, port, lockfile)
 				: new ModMonoWebSource (configurationManager.Filename, lockfile);
 
+            if (configurationManager.MinThreads.HasValue)
+                ThreadPool.SetMinThreads(configurationManager.MinThreads.Value, configurationManager.MinThreads.Value);
+
 			if(configurationManager.Terminate) {
 				if (configurationManager.Verbose)
 					Logger.Write (LogLevel.Notice, "Shutting down running mod-mono-server...");


### PR DESCRIPTION
When mod-mono-server is run on a different host than httpd we shouldn't send static files by sending only the file path to mod_mono.
