### PR TITLE
Allow 0.0.0.0/IPAddress.Any in FastCgi module

### DIFF
--- a/src/Mono.WebServer.Apache/ModMonoTCPWebSource.cs
+++ b/src/Mono.WebServer.Apache/ModMonoTCPWebSource.cs
@@ -40,9 +40,6 @@ namespace Mono.WebServer
 		public ModMonoTCPWebSource (IPAddress address, int port, string lockfile)
 			: base (lockfile)
 		{
-			if (address == IPAddress.Any)
-				address = IPAddress.Loopback;
-
 			SetListenAddress (address, port);
 		}
 		

--- a/src/Mono.WebServer.FastCgi/Sockets/TcpSocket.cs
+++ b/src/Mono.WebServer.FastCgi/Sockets/TcpSocket.cs
@@ -35,8 +35,7 @@ namespace Mono.WebServer.FastCgi.Sockets {
 		}
 		
 		public TcpSocket (System.Net.IPAddress address, int port)
-			: this (new System.Net.IPEndPoint (Equals(address, System.Net.IPAddress.Any) ?
-				System.Net.IPAddress.Loopback : address, port))
+			: this (new System.Net.IPEndPoint (address, port))
 		{
 		}
 	}


### PR DESCRIPTION
I couldn't dug up the reason why this was added in the first place, but it never worked anyway in the Apache module.
The original code added in [1] compared address to IPAddress with ==, but IPAddress doesn't overload == so this would do a reference comparison which is pointless.

The FastCgi code in [2] started out the same (because it was a copy of the Apache code), but somewhere down the line in [3] got refactored to use Equals which properly checks if "0.0.0.0" is the same as IPAdress.Any so this now accidentally "works".

Removing these checks as they prevent using 0.0.0.0 in the FastCgi module.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=38849

[1] https://github.com/mono/xsp/commit/27668ce4a89862c4ea8d4814a7fafb13ee73601d#diff-b3f046f8216096c242f36b2a223daafd
[2] https://github.com/shana/mono-soc-2007/commit/15cdbea0c9bc3e46c248ef40b4e9782911d027d9#diff-03fdd3e764b2b9d6788decf396baf4cc
[3] https://github.com/mono/xsp/commit/0f0cee3a3cc4658e2f3b29a3eb77cb4b878d4542

@grendello can you please take a look?