### PR TITLE
Remove usage of removed Mono.Security APIs and redirect xsp2 -> xsp4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -96,8 +96,6 @@ esac
 
 AM_CONDITIONAL(UNITTESTS, test x${UNIT_TESTS} = xyes)
 AM_CONDITIONAL(PLATFORM_WIN32, test x$platform_win32 = xyes)
-AM_CONDITIONAL(NET_2_0, test ! x$DMCS = xno)
-AM_CONDITIONAL(NET_4_0, test ! x$DMCS = xno)
 AM_CONDITIONAL(XSP_ONLY, test x$platform_win32 = xyes)
 
 # Put the version in the new required format (for svn revisions)

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -4,10 +4,8 @@ bin2_scripts_real = xsp2 mod-mono-server2 fastcgi-mono-server2
 bin2_scripts = $(bin2_scripts_real)
 tool2_scripts = asp-state2 dbsessmgr2
 
-if NET_4_0
 bin4_scripts = xsp4 mod-mono-server4 fastcgi-mono-server4
 tool4_scripts = asp-state4 dbsessmgr4
-endif
 
 bin_scripts = xsp mod-mono-server fastcgi-mono-server
 tool_scripts = asp-state dbsessmgr
@@ -18,19 +16,17 @@ bin_SCRIPTS = $(bin2_scripts) $(tool2_scripts) $(tool_scripts) $(bin_scripts) $(
 
 CLEANFILES = $(bin2_scripts_real) $(tool2_scripts) $(bin_scripts) $(tool_scripts) $(bin4_scripts) $(tool4_scripts) $(binplain_scripts)
 
-if NET_4_0
 plat_bindir4 = $(prefix)/lib/mono/4.5
 plat_tooldir4 = $(prefix)/lib/xsp/4.0
-endif
 
 REWRITE2 = sed \
 	-e 's,@''plat_bindir@,$(plat_bindir4),g'		\
-	-e 's,@''exe_file@,'`basename $@ 2`'2.exe,g'		\
+	-e 's,@''exe_file@,'`basename $@ 2`'4.exe,g'		\
 	-e 's,@''RUNTIME@,@RUNTIME@,g'
 
 REWRITE_TOOLS2 = echo dd $@ dd; sed \
 	-e 's,@''plat_bindir@,$(plat_tooldir4),g'		\
-	-e 's,@''exe_file@,'`basename $@ 2`'2.exe,g'		\
+	-e 's,@''exe_file@,'`basename $@ 2`'4.exe,g'		\
 	-e 's,@''RUNTIME@,@RUNTIME@,g'
 
 REWRITEPLAIN = sed \
@@ -38,7 +34,6 @@ REWRITEPLAIN = sed \
 	-e 's,@''exe_file@,'`basename $@ 4`'.exe,g'		\
 	-e 's,@''RUNTIME@,@RUNTIME@,g'
 
-if NET_4_0
 REWRITE4 = sed \
 	-e 's,@''plat_bindir@,$(plat_bindir4),g'		\
 	-e 's,@''exe_file@,'`basename $@ 4`'4.exe,g'		\
@@ -48,7 +43,6 @@ REWRITE_TOOLS4 = echo dd $@ dd; sed \
 	-e 's,@''plat_bindir@,$(plat_tooldir4),g'		\
 	-e 's,@''exe_file@,'`basename $@ 4`'4.exe,g'		\
 	-e 's,@''RUNTIME@,@RUNTIME@,g'
-endif
 
 $(bin2_scripts): $(srcdir)/script.in Makefile.am
 	$(REWRITE2) $(srcdir)/script.in > $@.tmp
@@ -70,7 +64,6 @@ $(tool_scripts): $(srcdir)/script.in Makefile.am
 	$(REWRITE_TOOLS2) $(srcdir)/script.in > $@.tmp
 	mv $@.tmp $@
 
-if NET_4_0
 $(bin4_scripts): $(srcdir)/script.in Makefile.am
 	$(REWRITE4) $(srcdir)/script.in > $@.tmp
 	mv $@.tmp $@
@@ -78,4 +71,3 @@ $(bin4_scripts): $(srcdir)/script.in Makefile.am
 $(tool4_scripts): $(srcdir)/script.in Makefile.am
 	$(REWRITE_TOOLS4) $(srcdir)/script.in > $@.tmp
 	mv $@.tmp $@
-endif

--- a/src/Mono.WebServer.FastCgi/Makefile.am
+++ b/src/Mono.WebServer.FastCgi/Makefile.am
@@ -19,7 +19,7 @@ build_sources = $(addprefix $(srcdir)/, $(sources)) AssemblyInfo.cs
 EXTRA_DIST = $(sources) AssemblyInfo.cs.in $(resources) Mono.WebServer.FastCgi.sources
 
 fastcgi-mono-server4.exe: $(build_sources)
-	$(DMCS) -d:NET_2_0 -d:NET_4_0 $(MCSFLAGS) $(references4) /out:$@ \
+	$(DMCS) $(MCSFLAGS) $(references4) /out:$@ \
 		$(build_sources)
 	$(SN) -q -R $(builddir)/$@ $(srcdir)/../mono.snk
 

--- a/src/Mono.WebServer.Fpm/Makefile.am
+++ b/src/Mono.WebServer.Fpm/Makefile.am
@@ -18,7 +18,7 @@ build_sources = $(addprefix $(srcdir)/, $(sources)) AssemblyInfo.cs
 EXTRA_DIST = $(sources) AssemblyInfo.cs.in $(resources) Mono.WebServer.Fpm.sources
 
 mono-fpm.exe: $(build_sources)
-	$(DMCS) -d:NET_2_0 -d:NET_4_0 $(MCSFLAGS) $(references) /out:$@ \
+	$(DMCS) $(MCSFLAGS) $(references) /out:$@ \
 		$(build_sources)
 	$(SN) -q -R $(builddir)/$@ $(srcdir)/../mono.snk
 

--- a/src/Mono.WebServer.XSP/ConfigurationManager.cs
+++ b/src/Mono.WebServer.XSP/ConfigurationManager.cs
@@ -28,7 +28,6 @@
 
 using System.Net;
 using Mono.WebServer.Options.Settings;
-using TP = Mono.Security.Protocol.Tls;
 using Mono.WebServer.Options;
 
 namespace Mono.WebServer.XSP {
@@ -38,9 +37,6 @@ namespace Mono.WebServer.XSP {
 		readonly BoolSetting nonstop = new BoolSetting ("nonstop", "Don't stop the server by pressing enter. Must be used when the server has no controlling terminal.");
 		readonly BoolSetting quiet = new BoolSetting ("quiet", "Disable the initial start up information.");
 		readonly BoolSetting randomPort = new BoolSetting ("random-port", "Listen on a randomly assigned port. The port numer will be reported to the caller via a text file.");
-		readonly BoolSetting https = new BoolSetting ("https", "Enable SSL for the server.");
-		readonly BoolSetting httpsClientAccept = new BoolSetting ("https-client-accept", "Enable SSL for the server with optional client certificates.");
-		readonly BoolSetting httpsClientRequire = new BoolSetting ("https-client-require", "Enable SSL for the server with mandatory client certificates.");
 		readonly BoolSetting noHidden = new BoolSetting ("no-hidden", "Allow access to hidden files (see 'man xsp' for details).");
 
 		readonly NullableInt32Setting minThreads = new NullableInt32Setting ("minThreads", "The minimum number of threads the thread pool creates on startup. Increase this value to handle a sudden inflow of connections.");
@@ -52,7 +48,6 @@ namespace Mono.WebServer.XSP {
 		readonly StringSetting pkPwd = new StringSetting ("pkpwd", "Password to decrypt the private key.");
 		readonly StringSetting pidFile = new StringSetting ("pidfile", "Write the process PID to the specified file.");
 
-		readonly EnumSetting<TP.SecurityProtocolType> protocols = new EnumSetting<TP.SecurityProtocolType> ("protocols", "specify which protocols are available for SSL. Possible values: Default (all), Tls, Ssl2, Ssl3", defaultValue: TP.SecurityProtocolType.Default);
 		#endregion
 
 		#region Typesafe properties
@@ -64,15 +59,6 @@ namespace Mono.WebServer.XSP {
 		}
 		public bool RandomPort {
 			get { return randomPort; }
-		}
-		public bool Https {
-			get { return https; }
-		}
-		public bool HttpsClientAccept {
-			get { return httpsClientAccept; }
-		}
-		public bool HttpsClientRequire {
-			get { return httpsClientRequire; }
 		}
 		public bool NoHidden {
 			get { return noHidden; }
@@ -101,9 +87,6 @@ namespace Mono.WebServer.XSP {
 			get { return pidFile; }
 		}
 
-		public TP.SecurityProtocolType Protocols {
-			get { return protocols; }
-		}
 		#endregion
 
 		public override string ProgramName {
@@ -118,10 +101,9 @@ namespace Mono.WebServer.XSP {
 
 		public ConfigurationManager (string name, bool quietDefault) : base (name)
 		{
-			Add (nonstop, quiet, randomPort, https, httpsClientAccept, httpsClientRequire, noHidden,
+			Add (nonstop, quiet, randomPort, noHidden,
 			     minThreads, port,
-			     p12File, cert, pkFile, pkPwd, pidFile,
-			     protocols);
+			     p12File, cert, pkFile, pkPwd, pidFile);
 			address.MaybeUpdate (SettingSource.Default, IPAddress.Any);
 			quiet.MaybeUpdate (SettingSource.Default, quietDefault);
 		}

--- a/src/Mono.WebServer.XSP/Makefile.am
+++ b/src/Mono.WebServer.XSP/Makefile.am
@@ -23,7 +23,7 @@ build_sources = $(addprefix $(srcdir)/, $(sources)) AssemblyInfo.cs
 EXTRA_DIST = $(sources) Mono.WebServer.XSP.sources AssemblyInfo.cs.in
 
 xsp4.exe: $(build_sources)
-	$(DMCS) -d:NET_2_0 -d:NET_4_0 $(MCSFLAGS) $(references4) /out:$@ $(build_sources)
+	$(DMCS) $(MCSFLAGS) $(references4) /out:$@ $(build_sources)
 	$(SN) -q -R $(builddir)/$@ $(srcdir)/../mono.snk
 
 install-data-local:

--- a/src/Mono.WebServer.XSP/SecurityConfiguration.cs
+++ b/src/Mono.WebServer.XSP/SecurityConfiguration.cs
@@ -36,7 +36,6 @@ using System.Text;
 using Mono.Security.Authenticode;
 using MSX = Mono.Security.X509;
 using Mono.Security.X509.Extensions;
-using SecurityProtocolType = Mono.Security.Protocol.Tls.SecurityProtocolType;
 
 namespace Mono.WebServer.XSP {
 
@@ -49,7 +48,6 @@ namespace Mono.WebServer.XSP {
 
 		public SecurityConfiguration ()
 		{
-			Protocol = SecurityProtocolType.Default;
 		}
 
 		// properties
@@ -87,8 +85,6 @@ namespace Mono.WebServer.XSP {
 			}
 		}
 
-		public SecurityProtocolType Protocol { get; set; }
-
 		// methods
 
 		public void CheckSecurityContextValidity ()
@@ -108,37 +104,10 @@ namespace Mono.WebServer.XSP {
 				return "(non-secure)";
 
 			var sb = new StringBuilder ("(");
-			switch (Protocol) {
-			case SecurityProtocolType.Default:
-				sb.Append ("auto-detect SSL3/TLS1");
-				break;
-			case SecurityProtocolType.Ssl3:
-				sb.Append ("SSL3");
-				break;
-			case SecurityProtocolType.Tls:
-				sb.Append ("TLS1");
-				break;
-			}
 			if (RequireClientCertificates)
 				sb.Append (" with mandatory client certificates");
 			sb.Append (")");
 			return sb.ToString ();
-		}
-
-		[Obsolete("Use the typesafe Protocol property")]
-		public void SetProtocol (string protocol)
-		{
-			if (protocol != null) {
-				try {
-					Protocol = (SecurityProtocolType) Enum.Parse (typeof (SecurityProtocolType), protocol);
-				}
-				catch (Exception e) {
-					string message = String.Format ("The value '{0}' given for security protocol is invalid.", protocol);
-					throw new CryptographicException (message, e);
-				}
-			} else {
-				Protocol = SecurityProtocolType.Default;
-			}
 		}
 
 		// private stuff

--- a/src/Mono.WebServer.XSP/XSPWebSource.cs
+++ b/src/Mono.WebServer.XSP/XSPWebSource.cs
@@ -30,9 +30,7 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
-using Mono.Security.Protocol.Tls;
 using Mono.WebServer.XSP;
-using SecurityProtocolType = Mono.Security.Protocol.Tls.SecurityProtocolType;
 using X509Certificate = System.Security.Cryptography.X509Certificates.X509Certificate;
 
 namespace Mono.WebServer {
@@ -43,22 +41,16 @@ namespace Mono.WebServer {
 	public class XSPWebSource: WebSource
 	{
 		IPEndPoint bindAddress;
-		readonly bool secureConnection;
-		readonly SecurityProtocolType securityProtocol;
 		readonly X509Certificate cert;
-		readonly PrivateKeySelectionCallback keyCB;
 		readonly bool allowClientCert;
 		readonly bool requireClientCert;
 
-		public XSPWebSource(IPAddress address, int port, SecurityProtocolType securityProtocol,
-				    X509Certificate cert, PrivateKeySelectionCallback keyCB, 
+		public XSPWebSource(IPAddress address, int port,
+				    X509Certificate cert,
 				    bool allowClientCert, bool requireClientCert, bool single_app)
 		{			
-			secureConnection = (cert != null && keyCB != null);
 			bindAddress = new IPEndPoint (address, port);
-			this.securityProtocol = securityProtocol;
 			this.cert = cert;
-			this.keyCB = keyCB;
 			this.allowClientCert = allowClientCert;
 			this.requireClientCert = requireClientCert;
 		}
@@ -101,7 +93,7 @@ namespace Mono.WebServer {
 		public override Worker CreateWorker (Socket client, ApplicationServer server)
 		{
 			return new XSPWorker (client, client.LocalEndPoint, server,
-				secureConnection, securityProtocol, cert, keyCB, allowClientCert, requireClientCert);
+				cert, allowClientCert, requireClientCert);
 		}
 		
 		public override Type GetApplicationHostType ()

--- a/src/Mono.WebServer.XSP/main.cs
+++ b/src/Mono.WebServer.XSP/main.cs
@@ -124,23 +124,7 @@ namespace Mono.WebServer.XSP
 
 			configurationManager.SetupLogger ();
 
-			WebSource webSource;
-			if (security.Enabled) {
-				try {
-					key = security.KeyPair;
-					webSource = new XSPWebSource (configurationManager.Address,
-						configurationManager.RandomPort ? default(ushort) : configurationManager.Port,
-						security.Protocol, security.ServerCertificate,
-						GetPrivateKey, security.AcceptClientCertificates,
-						security.RequireClientCertificates, !root);
-				}
-				catch (CryptographicException ce) {
-					Logger.Write (ce);
-					return new CompatTuple<int,string,ApplicationServer> (1, "Error while setting up https", null);
-				}
-			} else {
-				webSource = new XSPWebSource (configurationManager.Address, configurationManager.Port, !root);
-			}
+			WebSource webSource = new XSPWebSource (configurationManager.Address, configurationManager.Port, !root);
 
 			var server = new ApplicationServer (webSource, configurationManager.Root) {
 				Verbose = configurationManager.Verbose,
@@ -226,21 +210,6 @@ namespace Mono.WebServer.XSP
 				return false;
 			
 			// TODO: add mutual exclusivity rules
-			if(manager.Https)
-				security.Enabled = true;
-
-			if (manager.HttpsClientAccept) {
-				security.Enabled = true;
-				security.AcceptClientCertificates = true;
-				security.RequireClientCertificates = false;
-			}
-
-			if (manager.HttpsClientRequire) {
-				security.Enabled = true;
-				security.AcceptClientCertificates = true;
-				security.RequireClientCertificates = true;
-			}
-
 			if (manager.P12File != null)
 				security.Pkcs12File = manager.P12File;
 
@@ -252,8 +221,6 @@ namespace Mono.WebServer.XSP
 
 			if (manager.PkPwd != null)
 				security.Password = manager.PkPwd;
-
-			security.Protocol = manager.Protocols;
 
 			int minThreads = manager.MinThreads ?? 0;
 			if(minThreads > 0)

--- a/src/Mono.WebServer/Makefile.am
+++ b/src/Mono.WebServer/Makefile.am
@@ -19,7 +19,7 @@ monowebserver4_build_sources = $(addprefix $(srcdir)/, $(sources)) $(addprefix $
 
 4.0/Mono.WebServer2.dll: $(monowebserver4_build_sources)
 	-$(MKDIR_P) 4.0
-	$(DMCS) -d:NET_2_0 -d:NET_4_0 $(MCSFLAGS) $(monowebserver4_references) /target:library /out:$@ $(monowebserver4_build_sources)
+	$(DMCS) $(MCSFLAGS) $(monowebserver4_references) /target:library /out:$@ $(monowebserver4_build_sources)
 	$(SN) -q -R $(builddir)/$@ $(srcdir)/../mono.snk
 
 install-data-local:

--- a/src/Mono.WebServer/MonoWorkerRequest.cs
+++ b/src/Mono.WebServer/MonoWorkerRequest.cs
@@ -280,11 +280,7 @@ namespace Mono.WebServer
 			string hostVPath = HostVPath;
 			int hostVPathLen = HostVPath.Length;
 			int pathLen = path != null ? path.Length : 0;
-#if NET_2_0
 			bool inThisApp = path.StartsWith (hostVPath, StringComparison.Ordinal);
-#else
-			bool inThisApp = path.StartsWith (hostVPath);
-#endif
 			if (pathLen == 0 || (inThisApp && (pathLen == hostVPathLen || (pathLen == hostVPathLen + 1 && path [pathLen - 1] == '/')))) {
 				if (needToReplacePathSeparator)
 					return HostPath.Replace ('/', pathSeparatorChar);

--- a/tools/asp_state/Makefile.am
+++ b/tools/asp_state/Makefile.am
@@ -1,12 +1,10 @@
 MCSFLAGS= -debug+ -debug:full -nologo
 
-if NET_4_0
 scripts4 = asp-state4.exe
 data4 = asp-state4.exe.config
 aspstate4dir = $(prefix)/lib/xsp/4.0
 aspstate4_SCRIPTS = $(scripts4)
 aspstate4_DATA = $(data4)
-endif
 
 EXTRA_DIST = $(aspstate_input) asp-state4.exe.config
 CLEANFILES = *.exe *.mdb
@@ -16,7 +14,5 @@ aspstate_input = AssemblyInfo.cs.in \
 
 aspstate_sources = $(aspstate_input:.in=)
 
-if NET_4_0
 asp-state4.exe: $(aspstate_sources)
 	$(DMCS) $(MCSFLAGS) /out:$@ $^
-endif

--- a/tools/dbsessmgr/Makefile.am
+++ b/tools/dbsessmgr/Makefile.am
@@ -1,12 +1,10 @@
 MCSFLAGS= -debug+ -debug:full -nologo
 
-if NET_4_0
 scripts4 = dbsessmgr4.exe
 data4 = dbsessmgr4.exe.config
 dbsessmgr4dir = $(prefix)/lib/xsp/4.0
 dbsessmgr4_SCRIPTS = $(scripts4)
 dbsessmgr4_DATA = $(data4)
-endif
 
 EXTRA_DIST = $(dbsessmgr_input) dbsessmgr4.exe.config
 CLEANFILES = *.exe *.mdb
@@ -16,7 +14,5 @@ dbsessmgr_input = AssemblyInfo.cs.in \
 
 dbsessmgr_sources = $(dbsessmgr_input:.in=)
 
-if NET_4_0
 dbsessmgr4.exe: $(dbsessmgr_sources)
 	$(DMCS) $(MCSFLAGS) -r:System.Data.dll -r:System.Configuration.dll -out:$@ $^
-endif


### PR DESCRIPTION
With https://github.com/mono/mono/pull/17391 we don't have the legacy TLS provider anymore in Mono.