### PR TITLE
Fixes wrong addition of elapsed time during lingering close.

### DIFF
--- a/src/Mono.WebServer/LingeringNetworkStream.cs
+++ b/src/Mono.WebServer/LingeringNetworkStream.cs
@@ -73,7 +73,7 @@ namespace Mono.WebServer
 					if (nread == 0)
 						break;
 
-					waited += (int) (DateTime.UtcNow - start).TotalMilliseconds * 1000;
+					waited = (int) (DateTime.UtcNow - start).TotalMilliseconds * 1000;
 				}
 			} catch {
 				// ignore - we don't care, we're closing anyway


### PR DESCRIPTION
On each iteration receiving lingering data, the absolute time
elapsed from the begining of the loop was being added, instead
of only the time spent during current iteration.

This caused the loop to finishing to soon, hence provoking a
premature close of the socket, by which the client receives
some TCP/RSTs instead of a gracefull connection shutdown.