### PR TITLE
Optionally avoid slow dns lookups when calling XSPWorkerRequest.GetRemoteName()

### DIFF
--- a/src/Mono.WebServer.XSP/XSPWorkerRequest.cs
+++ b/src/Mono.WebServer.XSP/XSPWorkerRequest.cs
@@ -112,7 +112,7 @@ namespace Mono.WebServer
 				Logger.Write (ex);
 			}
 
-			Logger.Write (LogLevel.Standard, "Worker initialized with no_libc: {0}, no_dns_lookup: {1}, testing: {3}.", no_libc, no_dns_lookups, running_tests);
+			Logger.Write (LogLevel.Standard, "Worker initialized with no_libc: {0}, no_dns_lookup: {1}, testing: {2}.", no_libc, no_dns_lookups, running_tests);
 		}
 
 		static bool CheckOS ()

--- a/src/Mono.WebServer.XSP/XSPWorkerRequest.cs
+++ b/src/Mono.WebServer.XSP/XSPWorkerRequest.cs
@@ -76,6 +76,7 @@ namespace Mono.WebServer
 
 		static readonly bool running_tests;
 		static readonly bool no_libc;
+		static readonly bool no_dns_lookups;
 		static readonly string server_software;
 		static readonly string serverHeader;
 
@@ -89,6 +90,7 @@ namespace Mono.WebServer
 		static XSPWorkerRequest ()
 		{
 			no_libc = CheckOS ();
+			no_dns_lookups = CheckDisableDnsLookups();
 			running_tests = (Environment.GetEnvironmentVariable ("XSP_RUNNING_TESTS") != null);
 			Assembly assembly = Assembly.GetExecutingAssembly ();
 			string title = "Mono-XSP Server";
@@ -109,6 +111,8 @@ namespace Mono.WebServer
 				Logger.Write (LogLevel.Error, "Worker initialization exception occurred. Continuing anyway:");
 				Logger.Write (ex);
 			}
+
+			Logger.Write (LogLevel.Standard, "Worker initialized with no_libc: {0}, no_dns_lookup: {1}, testing: {3}.", no_libc, no_dns_lookups, running_tests);
 		}
 
 		static bool CheckOS ()
@@ -124,6 +128,29 @@ namespace Mono.WebServer
 			}
 
 			return !is_linux;
+		}
+
+		static bool CheckDisableDnsLookups()
+		{
+			bool result = false;
+			int dummy = 0;
+			string setting = Environment.GetEnvironmentVariable ("XSP_NO_DNS_LOOKUPS");
+
+			try {
+				setting = ConfigurationManager.AppSettings ["MonoServerDisableDnsLookups"] ?? setting;
+			} catch (Exception ex)
+			{
+				Logger.Write (LogLevel.Warning, "Unable to access MonoServerDisableDnsLookups appSetting.");
+				Logger.Write (ex);
+			}
+
+			if (bool.TryParse(setting, out result))
+				return result;
+
+			if (int.TryParse(setting, out dummy))
+				result = dummy != 0;
+
+			return result;
 		}
 
 		static void SetDefaultIndexFiles (string list)
@@ -487,6 +514,10 @@ namespace Mono.WebServer
 		{
 			string ip = GetRemoteAddress ();
 			string name;
+
+			if (no_dns_lookups) //< XXX: Avoid slow dns lookups
+				return ip;
+
 			try {
 				IPHostEntry entry = Dns.GetHostEntry (ip);
 				name = entry.HostName;


### PR DESCRIPTION
Hi,

While debugging a performance issue, we've found that when running an application under XSP any codepath accessing mono's System.Web.HttpRequest[x] (or the HttpRequest.ServerVariables collection), produces an slow request when such request comes from an IP address without a valid reverse dns entry (ie. in-addr.arpa records).

HttpRequest's internally uses ServerVariablesCollection.cs for fetching/composing server variables from the actual request, and inside the private method loadServerVariablesCollection, an unconditional access to '_request.UserHostName' is made to load wellknown headers/variables into the ServerVariableCollection instance.

See: https://github.com/mono/mono/blob/4f21911097cc819674fa2f5881c69e642577aed4/mcs/class/System.Web/System.Web/ServerVariablesCollection.cs#L200

This in turn, when running under XSP ends up calling https://github.com/mono/xsp/blob/65db4431a91e739a9e9bc1cfe927227f87529120/src/Mono.WebServer.XSP/XSPWorkerRequest.cs#L486, which again unconditionally tries to perform a reverse dns lookup against the IP address the request came from.

When using apache/mod-mono, this is not an issue, as the 'remote name' is provided by apache to mod-mono, so no Dns query has to be done at all, and wether the remote-name should be resolved or not is handled by apache's configuration. 

This is mostly the same when running under windows (IIS), as there are known methods to avoid / disable such an expensive dns lookup when using IIS.

However, we found no way to disable dns resolution of remote-name when using XSP, and this pull-request implements a new environment variable (XSP_NO_DNS_LOOKUPS) and appSetting, so the user can disable dns lookups if needed. Of course, this is implemented as an opt-out, so the existing behaviour is preserved by default.

Regards
Pablo